### PR TITLE
Simplify replacement calculations

### DIFF
--- a/src/main/java/com/github/voxxin/colourmyservers/mixin/CreateWorldMixin.java
+++ b/src/main/java/com/github/voxxin/colourmyservers/mixin/CreateWorldMixin.java
@@ -18,28 +18,7 @@ public abstract class CreateWorldMixin {
 
     @Inject(at = @At("HEAD"), method = "Lnet/minecraft/client/gui/screen/world/CreateWorldScreen;createLevelInfo(Z)Lnet/minecraft/world/level/LevelInfo;")
     public void saveNameMixin(boolean debugWorld, CallbackInfoReturnable<LevelInfo> cir) {
-        levelNameField.setText(levelNameField.getText().replace("&0", "§0"));
-        levelNameField.setText(levelNameField.getText().replace("&1", "§1"));
-        levelNameField.setText(levelNameField.getText().replace("&2", "§2"));
-        levelNameField.setText(levelNameField.getText().replace("&3", "§3"));
-        levelNameField.setText(levelNameField.getText().replace("&4", "§4"));
-        levelNameField.setText(levelNameField.getText().replace("&5", "§5"));
-        levelNameField.setText(levelNameField.getText().replace("&6", "§6"));
-        levelNameField.setText(levelNameField.getText().replace("&7", "§7"));
-        levelNameField.setText(levelNameField.getText().replace("&8", "§8"));
-        levelNameField.setText(levelNameField.getText().replace("&9", "§9"));
-        levelNameField.setText(levelNameField.getText().replace("&b", "§a"));
-        levelNameField.setText(levelNameField.getText().replace("&a", "§b"));
-        levelNameField.setText(levelNameField.getText().replace("&c", "§c"));
-        levelNameField.setText(levelNameField.getText().replace("&d", "§d"));
-        levelNameField.setText(levelNameField.getText().replace("&e", "§e"));
-        levelNameField.setText(levelNameField.getText().replace("&f", "§f"));
-
-        levelNameField.setText(levelNameField.getText().replace("&u", "§u"));
-        levelNameField.setText(levelNameField.getText().replace("&l", "§l"));
-        levelNameField.setText(levelNameField.getText().replace("&o", "§o"));
-        levelNameField.setText(levelNameField.getText().replace("&m", "§m"));
-        levelNameField.setText(levelNameField.getText().replace("&k", "§k"));
+        levelNameField.setText(levelNameField.getText().replace("&", "§"));
 
     }
 }

--- a/src/main/java/com/github/voxxin/colourmyservers/mixin/ServerNameMixin.java
+++ b/src/main/java/com/github/voxxin/colourmyservers/mixin/ServerNameMixin.java
@@ -53,28 +53,7 @@ public abstract class ServerNameMixin {
         // Changes provided colours back to a user readable format.
 
         if (serverNameField.getText() != "") {
-            serverNameField.setText(serverNameField.getText().replace("§0", "&0"));
-            serverNameField.setText(serverNameField.getText().replace("§1", "&1"));
-            serverNameField.setText(serverNameField.getText().replace("§2", "&2"));
-            serverNameField.setText(serverNameField.getText().replace("§3", "&3"));
-            serverNameField.setText(serverNameField.getText().replace("§4", "&4"));
-            serverNameField.setText(serverNameField.getText().replace("§5", "&5"));
-            serverNameField.setText(serverNameField.getText().replace("§6", "&6"));
-            serverNameField.setText(serverNameField.getText().replace("§7", "&7"));
-            serverNameField.setText(serverNameField.getText().replace("§8", "&8"));
-            serverNameField.setText(serverNameField.getText().replace("§9", "&9"));
-            serverNameField.setText(serverNameField.getText().replace("§b", "&a"));
-            serverNameField.setText(serverNameField.getText().replace("§a", "&b"));
-            serverNameField.setText(serverNameField.getText().replace("§c", "&c"));
-            serverNameField.setText(serverNameField.getText().replace("§d", "&d"));
-            serverNameField.setText(serverNameField.getText().replace("§e", "&e"));
-            serverNameField.setText(serverNameField.getText().replace("§f", "&f"));
-
-            serverNameField.setText(serverNameField.getText().replace("§u", "&u"));
-            serverNameField.setText(serverNameField.getText().replace("§l", "&l"));
-            serverNameField.setText(serverNameField.getText().replace("§o", "&o"));
-            serverNameField.setText(serverNameField.getText().replace("§m", "&m"));
-            serverNameField.setText(serverNameField.getText().replace("§k", "&k"));
+            serverNameField.setText(serverNameField.getText().replace("§", "&"));
         }
     }
 }

--- a/src/main/java/com/github/voxxin/colourmyservers/mixin/WorldNameEditMixin.java
+++ b/src/main/java/com/github/voxxin/colourmyservers/mixin/WorldNameEditMixin.java
@@ -17,56 +17,14 @@ public abstract class WorldNameEditMixin {
 
     @Inject(at = @At("HEAD"), method = "Lnet/minecraft/client/gui/screen/world/EditWorldScreen;commit()V")
     public void nameCommitMixin(CallbackInfo ci) {
-        levelNameTextField.setText(levelNameTextField.getText().replace("&0", "§0"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&1", "§1"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&2", "§2"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&3", "§3"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&4", "§4"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&5", "§5"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&6", "§6"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&7", "§7"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&8", "§8"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&9", "§9"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&b", "§a"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&a", "§b"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&c", "§c"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&d", "§d"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&e", "§e"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&f", "§f"));
-
-        levelNameTextField.setText(levelNameTextField.getText().replace("&u", "§u"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&l", "§l"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&o", "§o"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&m", "§m"));
-        levelNameTextField.setText(levelNameTextField.getText().replace("&k", "§k"));
+        levelNameTextField.setText(levelNameTextField.getText().replace("&", "§"));
     }
 
     @Inject(at = @At("TAIL"), method = "Lnet/minecraft/client/gui/screen/world/EditWorldScreen;init()V")
     public void worldNameMixin(CallbackInfo ci) {
 
         if (levelNameTextField.getText() != "") {
-            levelNameTextField.setText(levelNameTextField.getText().replace("§0", "&0"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§1", "&1"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§2", "&2"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§3", "&3"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§4", "&4"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§5", "&5"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§6", "&6"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§7", "&7"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§8", "&8"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§9", "&9"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§b", "&a"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§a", "&b"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§c", "&c"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§d", "&d"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§e", "&e"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§f", "&f"));
-
-            levelNameTextField.setText(levelNameTextField.getText().replace("§u", "&u"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§l", "&l"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§o", "&o"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§m", "&m"));
-            levelNameTextField.setText(levelNameTextField.getText().replace("§k", "&k"));
+            levelNameTextField.setText(levelNameTextField.getText().replace("§", "&"));
         }
     }
 }


### PR DESCRIPTION
Instead of individually declaring colour codes, why not just replace the `&` symbol with the section sign (`§`) in general? More readable and saves a little bit of time.